### PR TITLE
fix: correct path for decoded service account key in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Decode service-account-key.json from secret
       run: |
-        echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}" | base64 -d > "${HOME}/service-account-key.json"
+        echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}" | base64 -d > "${HOME}/functions/service-account-key.json"
     
     # Note: The predeploy steps (lint and build) are defined in firebase.json
     # and will be automatically executed by the Firebase CLI


### PR DESCRIPTION
- Updated the output path for the decoded service-account-key.json from "${HOME}/service-account-key.json" to "${HOME}/functions/service-account-key.json" in the deploy.yml workflow.